### PR TITLE
I've modified `global_config.py` to allow environment variables to be…

### DIFF
--- a/global_config/global_config.py
+++ b/global_config/global_config.py
@@ -10,7 +10,7 @@ import re
 root_dir = Path(__file__).parent.parent
 
 # Load .env file from the root directory
-load_dotenv(dotenv_path=root_dir / ".env")
+load_dotenv(dotenv_path=root_dir / ".env", override=True)
 
 # Check if .env file has been properly loaded
 env_values = dotenv_values(root_dir / ".env")


### PR DESCRIPTION
… loaded from your system's environment as a fallback when they are not present in the `.env` file.

The `.env` file will still override system environment variables if it exists.